### PR TITLE
ci: add composition check via supergraph compose

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -8,8 +8,30 @@ on:
 
 jobs:
   prepare_schema:
-    if: false
     uses: ./.github/workflows/apollo.yaml
+
+  compose:
+    name: Composition Check
+    needs: [prepare_schema]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download schema artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.prepare_schema.outputs.schema_artifact }}
+      - name: Install Rover
+        run: |
+          curl -sSL https://rover.apollo.dev/nix/latest | sh
+          echo "$HOME/.rover/bin" >> $GITHUB_PATH
+      - name: Compose
+        run: |
+          echo "federation_version: =2.10.0" > /tmp/supergraph.yaml
+          echo "subgraphs:" >> /tmp/supergraph.yaml
+          echo "  template:" >> /tmp/supergraph.yaml
+          echo "    routing_url: http://localhost:4001" >> /tmp/supergraph.yaml
+          echo "    schema:" >> /tmp/supergraph.yaml
+          echo "      file: ./${{ needs.prepare_schema.outputs.schema }}" >> /tmp/supergraph.yaml
+          rover supergraph compose --config /tmp/supergraph.yaml
 
   check_schema:
     name: Check Schema with Apollo Studio


### PR DESCRIPTION
## Summary
- Enable schema introspection step (was gated with `if: false`)
- Add `compose` job that runs `rover supergraph compose` to validate the introspected schema composes correctly in a supergraph
- Reuses the existing `apollo.yaml` workflow for schema introspection

## Test plan
- [ ] CI passes on this PR (test + prepare_schema + compose jobs)
- [ ] Verify composition check catches invalid federation schemas